### PR TITLE
Swift 2.0 compatibility

### DIFF
--- a/Example.xcodeproj/project.pbxproj
+++ b/Example.xcodeproj/project.pbxproj
@@ -260,7 +260,8 @@
 		4D248EFF1A751C3700E44E6B /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0620;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Alexander Schuch";
 				TargetAttributes = {
 					4D248F061A751C3700E44E6B = {
@@ -410,6 +411,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -473,6 +475,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.aschuch.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -483,6 +486,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Example/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.aschuch.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -503,6 +507,7 @@
 				INFOPLIST_FILE = QRCode/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.aschuch.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -524,6 +529,7 @@
 				INFOPLIST_FILE = QRCode/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.aschuch.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -545,6 +551,7 @@
 				);
 				INFOPLIST_FILE = QRCodeTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.aschuch.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
 			};
@@ -559,6 +566,7 @@
 				);
 				INFOPLIST_FILE = QRCodeTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.aschuch.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
 			};

--- a/Example.xcodeproj/xcshareddata/xcschemes/QRCode.xcscheme
+++ b/Example.xcodeproj/xcshareddata/xcschemes/QRCode.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0620"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,21 +23,24 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -52,10 +55,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/Example.xcodeproj/xcshareddata/xcschemes/QRCodeTests.xcscheme
+++ b/Example.xcodeproj/xcshareddata/xcschemes/QRCodeTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0620"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -48,15 +48,18 @@
             ReferencedContainer = "container:Example.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -71,20 +74,11 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4D248F3A1A751C7800E44E6B"
-            BuildableName = "QRCodeTests.xctest"
-            BlueprintName = "QRCodeTests"
-            ReferencedContainer = "container:Example.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.aschuch.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/QRCode/CIColorExtension.swift
+++ b/QRCode/CIColorExtension.swift
@@ -29,7 +29,7 @@ public extension CIColor {
         var hexValue: CUnsignedLongLong = 0
         
         if scanner.scanHexLongLong(&hexValue) {
-            let length = count(rgba)
+            let length = rgba.characters.count
             
             switch (length) {
             case 3:
@@ -51,11 +51,11 @@ public extension CIColor {
                 b = CGFloat((hexValue & 0x0000FF00) >> 8)   / 255.0
                 a = CGFloat(hexValue & 0x000000FF)          / 255.0
             default:
-                println("Invalid number of values (\(length)) in HEX string. Make sure to enter 3, 4, 6 or 8 values. E.g. `aabbccff`")
+                print("Invalid number of values (\(length)) in HEX string. Make sure to enter 3, 4, 6 or 8 values. E.g. `aabbccff`")
             }
             
         } else {
-            println("Invalid HEX value: \(rgba)")
+            print("Invalid HEX value: \(rgba)")
         }
         
         self.init(red: r, green: g, blue: b, alpha: a)

--- a/QRCode/Info.plist
+++ b/QRCode/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.aschuch.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/QRCode/QRCode.swift
+++ b/QRCode/QRCode.swift
@@ -36,11 +36,11 @@ public struct QRCode {
     
     /// Foreground color of the output
     /// Defaults to black
-    public var color = CIColor(red: 0, green: 0, blue: 0)
+    public var color = CIColor(color: UIColor.blackColor())
     
     /// Background color of the output
     /// Defaults to white
-    public var backgroundColor = CIColor(red: 1, green: 1, blue: 1)
+    public var backgroundColor = CIColor(color: UIColor.whiteColor())
     
     /// Size of the output
     public var size = CGSize(width: 200, height: 200)
@@ -63,7 +63,7 @@ public struct QRCode {
     }
     
     public init?(_ url: NSURL) {
-        if let data = url.absoluteString?.dataUsingEncoding(NSISOLatin1StringEncoding) {
+        if let data = url.absoluteString.dataUsingEncoding(NSISOLatin1StringEncoding) {
             self.data = data
         } else {
             return nil
@@ -74,29 +74,29 @@ public struct QRCode {
     
     /// The QRCode's UIImage representation
     public var image: UIImage {
-        return UIImage(CIImage: ciImage)!
+        return UIImage(CIImage: ciImage)
     }
     
     /// The QRCode's CIImage representation
     public var ciImage: CIImage {
         // Generate QRCode
         let qrFilter = CIFilter(name: "CIQRCodeGenerator")
-        qrFilter.setDefaults()
-        qrFilter.setValue(data, forKey: "inputMessage")
-        qrFilter.setValue(self.errorCorrection.rawValue, forKey: "inputCorrectionLevel")
+        qrFilter!.setDefaults()
+        qrFilter!.setValue(data, forKey: "inputMessage")
+        qrFilter!.setValue(self.errorCorrection.rawValue, forKey: "inputCorrectionLevel")
         
         // Color code and background
         let colorFilter = CIFilter(name: "CIFalseColor")
-        colorFilter.setDefaults()
-        colorFilter.setValue(qrFilter.outputImage, forKey: "inputImage")
-        colorFilter.setValue(color, forKey: "inputColor0")
-        colorFilter.setValue(backgroundColor, forKey: "inputColor1")
+        colorFilter!.setDefaults()
+        colorFilter!.setValue(qrFilter!.outputImage, forKey: "inputImage")
+        colorFilter!.setValue(color, forKey: "inputColor0")
+        colorFilter!.setValue(backgroundColor, forKey: "inputColor1")
         
         // Size
         let sizeRatioX = size.width / DefaultQRCodeSize.width
         let sizeRatioY = size.height / DefaultQRCodeSize.height
         let transform = CGAffineTransformMakeScale(sizeRatioX, sizeRatioY)
-        let transformedImage = colorFilter.outputImage.imageByApplyingTransform(transform)
+        let transformedImage = colorFilter!.outputImage.imageByApplyingTransform(transform)
         
         return transformedImage
     }

--- a/QRCodeTests/Info.plist
+++ b/QRCodeTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.aschuch.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/QRCodeTests/QRCodeTests.swift
+++ b/QRCodeTests/QRCodeTests.swift
@@ -16,14 +16,14 @@ class QRCodeTests: XCTestCase {
         let qrCode = QRCode("hello")
         
         XCTAssert(qrCode != nil, "QRCode is nil")
-        XCTAssertEqual(CIColor(red: 0, green: 0, blue: 0), qrCode!.color, "Initial color is not black")
-        XCTAssertEqual(CIColor(red: 1, green: 1, blue: 1), qrCode!.backgroundColor, "Initial backgroundColor is not white")
+        XCTAssertEqual(CIColor(color: UIColor.blackColor()), qrCode!.color, "Initial color is not black")
+        XCTAssertEqual(CIColor(color: UIColor.whiteColor()), qrCode!.backgroundColor, "Initial backgroundColor is not white")
         XCTAssertEqual(CGSize(width: 200, height: 200), qrCode!.size, "Initial size is not 200x200")
     }
     
     func testInitWithData() {
         let data = "hello".dataUsingEncoding(NSISOLatin1StringEncoding)!
-        var qrCode = QRCode(data)
+        let qrCode = QRCode(data)
         
         XCTAssertEqual(data, qrCode.data, "data is not equal")
     }
@@ -31,7 +31,7 @@ class QRCodeTests: XCTestCase {
     func testInitWithString() {
         let string = "hello"
         let data = string.dataUsingEncoding(NSISOLatin1StringEncoding)!
-        var qrCode = QRCode(string)
+        let qrCode = QRCode(string)
         
         XCTAssert(qrCode != nil, "QRCode is nil")
         XCTAssertEqual(data, qrCode!.data, "data is not equal")
@@ -39,16 +39,16 @@ class QRCodeTests: XCTestCase {
 
     func testInitWithURL() {
         let url = NSURL(string: "http://example.com")!
-        let data = url.absoluteString!.dataUsingEncoding(NSISOLatin1StringEncoding)!
-        var qrCode = QRCode(url)
+        let data = url.absoluteString.dataUsingEncoding(NSISOLatin1StringEncoding)!
+        let qrCode = QRCode(url)
         
         XCTAssert(qrCode != nil, "QRCode is nil")
         XCTAssertEqual(data, qrCode!.data, "data is not equal")
     }
     
     func testColor() {
-        let red = CIColor(red: 1, green: 0, blue: 0)
-        let blue = CIColor(red: 0, green: 0, blue: 1)
+        let red = CIColor(color: UIColor.redColor())
+        let blue = CIColor(color: UIColor.blueColor())
         
         var qrCode = QRCode("hello")
         qrCode?.color = red


### PR DESCRIPTION
Hi,

this library is awesome, but it didn't work out of the box with Xcode 7.0 beta and the new Swift 2.0 syntax. So I converted the syntax and the project, to comply with Xcode 7.0.

Maybe you could leave the `swift-2.0` branch, so that Xcode 7.0 users can use the following line in their Podfile:

```
pod 'QRCode', :git => 'https://github.com/aschuch/QRCode', :branch => 'swift-2.0'
```

Thanks,
Marc
