### PR TITLE
Swift 2 compat changes

### DIFF
--- a/QRCode/CIColorExtension.swift
+++ b/QRCode/CIColorExtension.swift
@@ -29,7 +29,7 @@ public extension CIColor {
         var hexValue: CUnsignedLongLong = 0
         
         if scanner.scanHexLongLong(&hexValue) {
-            let length = count(rgba)
+            let length = rgba.characters.count
             
             switch (length) {
             case 3:

--- a/QRCode/CIColorExtension.swift
+++ b/QRCode/CIColorExtension.swift
@@ -51,11 +51,11 @@ public extension CIColor {
                 b = CGFloat((hexValue & 0x0000FF00) >> 8)   / 255.0
                 a = CGFloat(hexValue & 0x000000FF)          / 255.0
             default:
-                println("Invalid number of values (\(length)) in HEX string. Make sure to enter 3, 4, 6 or 8 values. E.g. `aabbccff`")
+                print("Invalid number of values (\(length)) in HEX string. Make sure to enter 3, 4, 6 or 8 values. E.g. `aabbccff`")
             }
             
         } else {
-            println("Invalid HEX value: \(rgba)")
+            print("Invalid HEX value: \(rgba)")
         }
         
         self.init(red: r, green: g, blue: b, alpha: a)

--- a/QRCode/QRCode.swift
+++ b/QRCode/QRCode.swift
@@ -63,7 +63,7 @@ public struct QRCode {
     }
     
     public init?(_ url: NSURL) {
-        if let data = url.absoluteString?.dataUsingEncoding(NSISOLatin1StringEncoding) {
+        if let data = url.absoluteString.dataUsingEncoding(NSISOLatin1StringEncoding) {
             self.data = data
         } else {
             return nil

--- a/QRCode/QRCode.swift
+++ b/QRCode/QRCode.swift
@@ -96,7 +96,7 @@ public struct QRCode {
         let sizeRatioX = size.width / DefaultQRCodeSize.width
         let sizeRatioY = size.height / DefaultQRCodeSize.height
         let transform = CGAffineTransformMakeScale(sizeRatioX, sizeRatioY)
-        let transformedImage = colorFilter.outputImage.imageByApplyingTransform(transform)
+        let transformedImage = colorFilter.outputImage!.imageByApplyingTransform(transform)
         
         return transformedImage
     }

--- a/QRCode/QRCode.swift
+++ b/QRCode/QRCode.swift
@@ -74,7 +74,7 @@ public struct QRCode {
     
     /// The QRCode's UIImage representation
     public var image: UIImage {
-        return UIImage(CIImage: ciImage)!
+        return UIImage(CIImage: ciImage)
     }
     
     /// The QRCode's CIImage representation

--- a/QRCode/QRCode.swift
+++ b/QRCode/QRCode.swift
@@ -80,13 +80,13 @@ public struct QRCode {
     /// The QRCode's CIImage representation
     public var ciImage: CIImage {
         // Generate QRCode
-        let qrFilter = CIFilter(name: "CIQRCodeGenerator")
+        let qrFilter = CIFilter(name: "CIQRCodeGenerator")!
         qrFilter.setDefaults()
         qrFilter.setValue(data, forKey: "inputMessage")
         qrFilter.setValue(self.errorCorrection.rawValue, forKey: "inputCorrectionLevel")
         
         // Color code and background
-        let colorFilter = CIFilter(name: "CIFalseColor")
+        let colorFilter = CIFilter(name: "CIFalseColor")!
         colorFilter.setDefaults()
         colorFilter.setValue(qrFilter.outputImage, forKey: "inputImage")
         colorFilter.setValue(color, forKey: "inputColor0")


### PR DESCRIPTION
This gets the code compiling on current Xcode. A lot of the affected changes are optional <-> non-optional.

This won't be compatible with older versions; for that such changes will need to be guarded with "if foo is Bar?" and the like.
