### PR TITLE
fix: capture image with device scale.

### DIFF
--- a/QRCode/CIImageExtension.swift
+++ b/QRCode/CIImageExtension.swift
@@ -21,7 +21,7 @@ internal extension CIImage {
         let cgImage = CIContext(options: nil).createCGImage(self, fromRect: self.extent)
         let size = CGSize(width: self.extent.size.width * scale.dx, height: self.extent.size.height * scale.dy)
         
-        UIGraphicsBeginImageContext(size)
+        UIGraphicsBeginImageContextWithOptions(size, true, 0)
         let context = UIGraphicsGetCurrentContext()
         
         CGContextSetInterpolationQuality(context, .None)


### PR DESCRIPTION
I encountered a problem that the result QRCode image is blurred.
So this commit simply capture the image with device scale solved that problem, and has no effect to other usages.
