### PR TITLE
* add support custom CIContextFactory.use it fix crash in iOS8

### DIFF
--- a/QRCode/CIImageExtension.swift
+++ b/QRCode/CIImageExtension.swift
@@ -18,7 +18,13 @@ internal extension CIImage {
     ///
     /// - returns: an non-interpolated UIImage
     internal func nonInterpolatedImage(withScale scale: Scale = Scale(dx: 1, dy: 1)) -> UIImage? {
-        guard let cgImage = CIContext(options: nil).createCGImage(self, from: self.extent) else { return nil }
+        var ciContext:CIContext?
+        if QRCode.CIContextFactory != nil {
+            ciContext = QRCode.CIContextFactory!()
+        }else{
+            ciContext = CIContext(options: nil)
+        }
+        guard let cgImage = ciContext?.createCGImage(self, from: self.extent) else { return nil }
         let size = CGSize(width: self.extent.size.width * scale.dx, height: self.extent.size.height * scale.dy)
         
         UIGraphicsBeginImageContextWithOptions(size, true, 0)

--- a/QRCode/QRCode.swift
+++ b/QRCode/QRCode.swift
@@ -13,6 +13,8 @@ public typealias 🔳 = QRCode
 /// QRCode generator
 public struct QRCode {
     
+    public static var CIContextFactory:(()->CIContext)?
+    
     /**
     The level of error correction.
     


### PR DESCRIPTION
read http://stackoverflow.com/questions/39570644 answer
create CIContext instance in object-c and set it to QRCode.CIContextFactory static field in iOS8.
example:
```swift
if #available(iOS 9.0, *){
  return
}
QRCode.CIContextFactory = {
  return CIContext.cso_context(options: nil)
}
```