### PR TITLE
String length in CIColorExtension

### DIFF
--- a/QRCode/CIColorExtension.swift
+++ b/QRCode/CIColorExtension.swift
@@ -29,7 +29,7 @@ public extension CIColor {
         var hexValue: CUnsignedLongLong = 0
         
         if scanner.scanHexInt64(&hexValue) {
-            let length = rgba.characters.count
+            let length = rgba.count
             
             switch (length) {
             case 3:


### PR DESCRIPTION
String.character.count is not available anymore in swift and the new way of doing that is by string.count.